### PR TITLE
Removing the master-slave terminology

### DIFF
--- a/venv/lib/python3.7/site-packages/boto/elastictranscoder/layer1.py
+++ b/venv/lib/python3.7/site-packages/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/venv/lib/python3.7/site-packages/boto/emr/connection.py
+++ b/venv/lib/python3.7/site-packages/boto/emr/connection.py
@@ -408,8 +408,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -436,11 +436,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -471,7 +471,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -526,15 +526,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -721,15 +721,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/venv/lib/python3.7/site-packages/boto/emr/step.py
+++ b/venv/lib/python3.7/site-packages/boto/emr/step.py
@@ -132,7 +132,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/venv/lib/python3.7/site-packages/boto/kms/layer1.py
+++ b/venv/lib/python3.7/site-packages/boto/kms/layer1.py
@@ -130,7 +130,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_alias(self, alias_name, target_key_id):
         """
-        Creates a display name for a customer master key. An alias can
+        Creates a display name for a customer main key. An alias can
         be used to identify a key and should be unique. The console
         enforces a one-to-one mapping between the alias and a key. An
         alias name can contain only alphanumeric characters, forward
@@ -174,7 +174,7 @@ class KMSConnection(AWSQueryConnection):
         #. RevokeGrant
 
         :type key_id: string
-        :param key_id: A unique key identifier for a customer master key. This
+        :param key_id: A unique key identifier for a customer main key. This
             value can be a globally unique identifier, an ARN, or an alias.
 
         :type grantee_principal: string
@@ -222,7 +222,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_key(self, policy=None, description=None, key_usage=None):
         """
-        Creates a customer master key. Customer master keys can be
+        Creates a customer main key. Customer main keys can be
         used to encrypt small amounts of data (less than 4K) directly,
         but they are most commonly used to encrypt or envelope data
         keys that are then used to encrypt customer data. For more
@@ -306,10 +306,10 @@ class KMSConnection(AWSQueryConnection):
     def describe_key(self, key_id):
         """
         Provides detailed information about the specified customer
-        master key.
+        main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             described. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -323,7 +323,7 @@ class KMSConnection(AWSQueryConnection):
         Marks a key as disabled, thereby preventing its use.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             disabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -337,7 +337,7 @@ class KMSConnection(AWSQueryConnection):
         Disables rotation of the specified key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be disabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -352,7 +352,7 @@ class KMSConnection(AWSQueryConnection):
         have up to 25 enabled keys at one time.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             enabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -363,10 +363,10 @@ class KMSConnection(AWSQueryConnection):
 
     def enable_key_rotation(self, key_id):
         """
-        Enables rotation of the specified customer master key.
+        Enables rotation of the specified customer main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be enabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -378,11 +378,11 @@ class KMSConnection(AWSQueryConnection):
     def encrypt(self, key_id, plaintext, encryption_context=None,
                 grant_tokens=None):
         """
-        Encrypts plaintext into ciphertext by using a customer master
+        Encrypts plaintext into ciphertext by using a customer main
         key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master. This can be an
+        :param key_id: Unique identifier of the customer main. This can be an
             ARN, an alias, or the Key ID.
 
         :type plaintext: blob
@@ -420,7 +420,7 @@ class KMSConnection(AWSQueryConnection):
                           grant_tokens=None):
         """
         Generates a secure data key. Data keys are used to encrypt and
-        decrypt data. They are wrapped by customer master keys.
+        decrypt data. They are wrapped by customer main keys.
 
         :type key_id: string
         :param key_id: Unique identifier of the key. This can be an ARN, an
@@ -472,7 +472,7 @@ class KMSConnection(AWSQueryConnection):
                                             number_of_bytes=None,
                                             grant_tokens=None):
         """
-        Returns a key wrapped by a customer master key without the
+        Returns a key wrapped by a customer main key without the
         plaintext copy of that key. To retrieve the plaintext, see
         GenerateDataKey.
 
@@ -651,7 +651,7 @@ class KMSConnection(AWSQueryConnection):
 
     def list_keys(self, limit=None, marker=None):
         """
-        Lists the customer master keys.
+        Lists the customer main keys.
 
         :type limit: integer
         :param limit: Specify this parameter only when paginating results to
@@ -702,7 +702,7 @@ class KMSConnection(AWSQueryConnection):
                    source_encryption_context=None,
                    destination_encryption_context=None, grant_tokens=None):
         """
-        Encrypts data on the server side with a new customer master
+        Encrypts data on the server side with a new customer main
         key without exposing the plaintext of the data on the client
         side. The data is first decrypted and then encrypted. This
         operation can also be used to change the encryption context of

--- a/venv/lib/python3.7/site-packages/boto/opsworks/layer1.py
+++ b/venv/lib/python3.7/site-packages/boto/opsworks/layer1.py
@@ -2124,7 +2124,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The database's master user name.
+        :param db_user: The database's main user name.
 
         :type db_password: string
         :param db_password: The database password.
@@ -2785,7 +2785,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The master user name.
+        :param db_user: The main user name.
 
         :type db_password: string
         :param db_password: The database password.

--- a/venv/lib/python3.7/site-packages/boto/pyami/bootstrap.py
+++ b/venv/lib/python3.7/site-packages/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/venv/lib/python3.7/site-packages/boto/rds/__init__.py
+++ b/venv/lib/python3.7/site-packages/boto/rds/__init__.py
@@ -138,8 +138,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -168,8 +168,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -222,8 +222,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -240,8 +240,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -398,8 +398,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -423,8 +423,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -562,7 +562,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -593,8 +593,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -680,8 +680,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/venv/lib/python3.7/site-packages/boto/rds/dbinstance.py
+++ b/venv/lib/python3.7/site-packages/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/venv/lib/python3.7/site-packages/boto/rds/dbsnapshot.py
+++ b/venv/lib/python3.7/site-packages/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/venv/lib/python3.7/site-packages/boto/rds2/layer1.py
+++ b/venv/lib/python3.7/site-packages/boto/rds2/layer1.py
@@ -321,8 +321,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -417,9 +417,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -452,8 +452,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -536,7 +536,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -656,8 +656,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2488,7 +2488,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2616,14 +2616,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2634,7 +2634,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2668,7 +2668,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2820,8 +2820,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/venv/lib/python3.7/site-packages/boto/redshift/layer1.py
+++ b/venv/lib/python3.7/site-packages/boto/redshift/layer1.py
@@ -310,8 +310,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -391,9 +391,9 @@ class RedshiftConnection(AWSQueryConnection):
         Valid Values: `dw1.xlarge` | `dw1.8xlarge` | `dw2.large` |
             `dw2.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -404,9 +404,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -573,8 +573,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2253,7 +2253,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2264,7 +2264,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying a parameter group requires a reboot for parameters
@@ -2345,11 +2345,11 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of virtual private cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2464,8 +2464,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/venv/lib/python3.7/site-packages/pip-19.0.3-py3.7.egg/pip/_internal/vcs/git.py
+++ b/venv/lib/python3.7/site-packages/pip-19.0.3-py3.7.egg/pip/_internal/vcs/git.py
@@ -242,7 +242,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q', '--tags'], cwd=dest)
         else:
             self.run_command(['fetch', '-q'], cwd=dest)
-        # Then reset to wanted revision (maybe even origin/master)
+        # Then reset to wanted revision (maybe even origin/main)
         rev_options = self.resolve_revision(dest, url, rev_options)
         cmd_args = ['reset', '--hard', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)

--- a/venv/lib/python3.7/site-packages/pip-19.0.3-py3.7.egg/pip/_vendor/pkg_resources/__init__.py
+++ b/venv/lib/python3.7/site-packages/pip-19.0.3-py3.7.egg/pip/_vendor/pkg_resources/__init__.py
@@ -565,9 +565,9 @@ class WorkingSet:
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3124,9 +3124,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3136,7 +3136,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/venv/lib/python3.7/site-packages/pymongo/collection.py
+++ b/venv/lib/python3.7/site-packages/pymongo/collection.py
@@ -87,7 +87,7 @@ class Collection(common.BaseObject):
         .. mongodoc:: collections
         """
         super(Collection, self).__init__(
-            slave_okay=database.slave_okay,
+            subordinate_okay=database.subordinate_okay,
             read_preference=database.read_preference,
             tag_sets=database.tag_sets,
             secondary_acceptable_latency_ms=(
@@ -784,7 +784,7 @@ class Collection(common.BaseObject):
           - `as_class` (optional): class to use for documents in the
             query result (default is
             :attr:`~pymongo.mongo_client.MongoClient.document_class`)
-          - `slave_okay` (optional): if True, allows this query to
+          - `subordinate_okay` (optional): if True, allows this query to
             be run against a replica secondary.
           - `await_data` (optional): if True, the server will block for
             some extra time before returning, waiting for more data to
@@ -865,8 +865,8 @@ class Collection(common.BaseObject):
         .. mongodoc:: find
         .. _localThreshold: http://docs.mongodb.org/manual/reference/mongos/#cmdoption-mongos--localThreshold
         """
-        if not 'slave_okay' in kwargs:
-            kwargs['slave_okay'] = self.slave_okay
+        if not 'subordinate_okay' in kwargs:
+            kwargs['subordinate_okay'] = self.subordinate_okay
         if not 'read_preference' in kwargs:
             kwargs['read_preference'] = self.read_preference
         if not 'tag_sets' in kwargs:
@@ -907,11 +907,11 @@ class Collection(common.BaseObject):
             # All documents have now been processed.
 
         With :class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`
-        or :class:`~pymongo.master_slave_connection.MasterSlaveConnection`,
+        or :class:`~pymongo.main_subordinate_connection.MainSubordinateConnection`,
         if the `read_preference` attribute of this instance is not set to
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY` or the
-        (deprecated) `slave_okay` attribute of this instance is set to `True`
-        the command will be sent to a secondary or slave.
+        (deprecated) `subordinate_okay` attribute of this instance is set to `True`
+        the command will be sent to a secondary or subordinate.
 
         :Parameters:
           - `num_cursors`: the number of cursors to return
@@ -919,7 +919,7 @@ class Collection(common.BaseObject):
         .. note:: Requires server version **>= 2.5.5**.
 
         """
-        use_master = not self.slave_okay and not self.read_preference
+        use_main = not self.subordinate_okay and not self.read_preference
         compile_re = kwargs.get('compile_re', False)
 
         command_kwargs = {
@@ -928,8 +928,8 @@ class Collection(common.BaseObject):
             'tag_sets': self.tag_sets,
             'secondary_acceptable_latency_ms': (
                 self.secondary_acceptable_latency_ms),
-            'slave_okay': self.slave_okay,
-            '_use_master': use_master}
+            'subordinate_okay': self.subordinate_okay,
+            '_use_main': use_main}
         command_kwargs.update(kwargs)
 
         result, conn_id = self.__database._command(
@@ -1270,11 +1270,11 @@ class Collection(common.BaseObject):
         client = self.database.connection
         client._ensure_connected(True)
 
-        slave_okay = not client._rs_client and not client.is_mongos
+        subordinate_okay = not client._rs_client and not client.is_mongos
         if client.max_wire_version > 2:
             res, addr = self.__database._command(
                 "listIndexes", self.__name, as_class=SON,
-                cursor={}, slave_okay=slave_okay,
+                cursor={}, subordinate_okay=subordinate_okay,
                 read_preference=ReadPreference.PRIMARY)
             # MongoDB 2.8rc2
             if "indexes" in res:
@@ -1285,8 +1285,8 @@ class Collection(common.BaseObject):
         else:
             raw = self.__database.system.indexes.find({"ns": self.__full_name},
                                                       {"ns": 0}, as_class=SON,
-                                                      slave_okay=slave_okay,
-                                                      _must_use_master=True)
+                                                      subordinate_okay=subordinate_okay,
+                                                      _must_use_main=True)
         info = {}
         for index in raw:
             index["key"] = list(index["key"].items())
@@ -1306,14 +1306,14 @@ class Collection(common.BaseObject):
         client._ensure_connected(True)
 
         result = None
-        slave_okay = not client._rs_client and not client.is_mongos
+        subordinate_okay = not client._rs_client and not client.is_mongos
         if client.max_wire_version > 2:
             res, addr = self.__database._command(
                 "listCollections",
                 cursor={},
                 filter={"name": self.__name},
                 read_preference=ReadPreference.PRIMARY,
-                slave_okay=slave_okay)
+                subordinate_okay=subordinate_okay)
             # MongoDB 2.8rc2
             if "collections" in res:
                 results = res["collections"]
@@ -1326,8 +1326,8 @@ class Collection(common.BaseObject):
         else:
             result = self.__database.system.namespaces.find_one(
                 {"name": self.__full_name},
-                slave_okay=slave_okay,
-                _must_use_master=True)
+                subordinate_okay=subordinate_okay,
+                _must_use_main=True)
 
         if not result:
             return {}
@@ -1343,11 +1343,11 @@ class Collection(common.BaseObject):
         collection.
 
         With :class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`
-        or :class:`~pymongo.master_slave_connection.MasterSlaveConnection`,
+        or :class:`~pymongo.main_subordinate_connection.MainSubordinateConnection`,
         if the `read_preference` attribute of this instance is not set to
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY` or the
-        (deprecated) `slave_okay` attribute of this instance is set to `True`
-        the `aggregate command`_ will be sent to a secondary or slave.
+        (deprecated) `subordinate_okay` attribute of this instance is set to `True`
+        the `aggregate command`_ will be sent to a secondary or subordinate.
 
         :Parameters:
           - `pipeline`: a single command or list of aggregation commands
@@ -1381,7 +1381,7 @@ class Collection(common.BaseObject):
         if isinstance(pipeline, dict):
             pipeline = [pipeline]
 
-        use_master = not self.slave_okay and not self.read_preference
+        use_main = not self.subordinate_okay and not self.read_preference
 
         command_kwargs = {
             'pipeline': pipeline,
@@ -1389,8 +1389,8 @@ class Collection(common.BaseObject):
             'tag_sets': self.tag_sets,
             'secondary_acceptable_latency_ms': (
                 self.secondary_acceptable_latency_ms),
-            'slave_okay': self.slave_okay,
-            '_use_master': use_master}
+            'subordinate_okay': self.subordinate_okay,
+            '_use_main': use_main}
 
         command_kwargs.update(kwargs)
         result, conn_id = self.__database._command(
@@ -1423,12 +1423,12 @@ class Collection(common.BaseObject):
             to group by.
 
         With :class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`
-        or :class:`~pymongo.master_slave_connection.MasterSlaveConnection`,
+        or :class:`~pymongo.main_subordinate_connection.MainSubordinateConnection`,
         if the `read_preference` attribute of this instance is not set to
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY` or
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY_PREFERRED`, or
-        the (deprecated) `slave_okay` attribute of this instance is set to
-        `True`, the group command will be sent to a secondary or slave.
+        the (deprecated) `subordinate_okay` attribute of this instance is set to
+        `True`, the group command will be sent to a secondary or subordinate.
 
         :Parameters:
           - `key`: fields to group by (see above description)
@@ -1461,7 +1461,7 @@ class Collection(common.BaseObject):
         if finalize is not None:
             group["finalize"] = Code(finalize)
 
-        use_master = not self.slave_okay and not self.read_preference
+        use_main = not self.subordinate_okay and not self.read_preference
 
         return self.__database.command("group", group,
                                        uuid_subtype=self.uuid_subtype,
@@ -1469,8 +1469,8 @@ class Collection(common.BaseObject):
                                        tag_sets=self.tag_sets,
                                        secondary_acceptable_latency_ms=(
                                            self.secondary_acceptable_latency_ms),
-                                       slave_okay=self.slave_okay,
-                                       _use_master=use_master,
+                                       subordinate_okay=self.subordinate_okay,
+                                       _use_main=use_main,
                                        **kwargs)["retval"]
 
     def rename(self, new_name, **kwargs):
@@ -1572,9 +1572,9 @@ class Collection(common.BaseObject):
                             "%s or dict" % (str.__name__,))
 
         if isinstance(out, dict) and out.get('inline'):
-            must_use_master = False
+            must_use_main = False
         else:
-            must_use_master = True
+            must_use_main = True
 
         response = self.__database.command("mapreduce", self.__name,
                                            uuid_subtype=self.uuid_subtype,
@@ -1583,7 +1583,7 @@ class Collection(common.BaseObject):
                                            tag_sets=self.tag_sets,
                                            secondary_acceptable_latency_ms=(
                                                self.secondary_acceptable_latency_ms),
-                                           out=out, _use_master=must_use_master,
+                                           out=out, _use_main=must_use_main,
                                            **kwargs)
 
         if full_response or not response.get('result'):
@@ -1607,12 +1607,12 @@ class Collection(common.BaseObject):
         response from the server to the `map reduce command`_.
 
         With :class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`
-        or :class:`~pymongo.master_slave_connection.MasterSlaveConnection`,
+        or :class:`~pymongo.main_subordinate_connection.MainSubordinateConnection`,
         if the `read_preference` attribute of this instance is not set to
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY` or
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY_PREFERRED`, or
-        the (deprecated) `slave_okay` attribute of this instance is set to
-        `True`, the inline map reduce will be run on a secondary or slave.
+        the (deprecated) `subordinate_okay` attribute of this instance is set to
+        `True`, the inline map reduce will be run on a secondary or subordinate.
 
         :Parameters:
           - `map`: map function (as a JavaScript string)
@@ -1630,7 +1630,7 @@ class Collection(common.BaseObject):
         .. versionadded:: 1.10
         """
 
-        use_master = not self.slave_okay and not self.read_preference
+        use_main = not self.subordinate_okay and not self.read_preference
 
         res = self.__database.command("mapreduce", self.__name,
                                       uuid_subtype=self.uuid_subtype,
@@ -1638,8 +1638,8 @@ class Collection(common.BaseObject):
                                       tag_sets=self.tag_sets,
                                       secondary_acceptable_latency_ms=(
                                           self.secondary_acceptable_latency_ms),
-                                      slave_okay=self.slave_okay,
-                                      _use_master=use_master,
+                                      subordinate_okay=self.subordinate_okay,
+                                      _use_main=use_main,
                                       map=map, reduce=reduce,
                                       out={"inline": 1}, **kwargs)
 

--- a/venv/lib/python3.7/site-packages/pymongo/command_cursor.py
+++ b/venv/lib/python3.7/site-packages/pymongo/command_cursor.py
@@ -117,7 +117,7 @@ class CommandCursor(object):
             self.__killed = True
             raise
         except AutoReconnect:
-            # Don't send kill cursors to another server after a "not master"
+            # Don't send kill cursors to another server after a "not main"
             # error. It's completely pointless.
             self.__killed = True
             client.disconnect()

--- a/venv/lib/python3.7/site-packages/pymongo/common.py
+++ b/venv/lib/python3.7/site-packages/pymongo/common.py
@@ -303,8 +303,8 @@ def validate_auth_mechanism_properties(option, value):
 # readpreferencetags is an alias for tag_sets.
 VALIDATORS = {
     'replicaset': validate_basestring_or_none,
-    'slaveok': validate_boolean,
-    'slave_okay': validate_boolean,
+    'subordinateok': validate_boolean,
+    'subordinate_okay': validate_boolean,
     'safe': validate_boolean,
     'w': validate_int_or_basestring,
     'wtimeout': validate_integer,
@@ -395,7 +395,7 @@ class BaseObject(object):
 
     def __init__(self, **options):
 
-        self.__slave_okay = False
+        self.__subordinate_okay = False
         self.__read_pref = ReadPreference.PRIMARY
         self.__tag_sets = [{}]
         self.__secondary_acceptable_latency_ms = 15
@@ -438,8 +438,8 @@ class BaseObject(object):
     def __set_options(self, options):
         """Validates and sets all options passed to this object."""
         for option, value in options.items():
-            if option in ('slave_okay', 'slaveok'):
-                self.__slave_okay = validate_boolean(option, value)
+            if option in ('subordinate_okay', 'subordinateok'):
+                self.__subordinate_okay = validate_boolean(option, value)
             elif option in ('read_preference', "readpreference"):
                 self.__read_pref = validate_read_preference(option, value)
             elif option in ('tag_sets', 'readpreferencetags'):
@@ -533,23 +533,23 @@ class BaseObject(object):
 
     write_concern = property(__get_write_concern, __set_write_concern)
 
-    def __get_slave_okay(self):
+    def __get_subordinate_okay(self):
         """DEPRECATED. Use :attr:`read_preference` instead.
 
         .. versionchanged:: 2.1
-           Deprecated slave_okay.
+           Deprecated subordinate_okay.
         .. versionadded:: 2.0
         """
-        return self.__slave_okay
+        return self.__subordinate_okay
 
-    def __set_slave_okay(self, value):
-        """Property setter for slave_okay"""
-        warnings.warn("slave_okay is deprecated. Please use "
+    def __set_subordinate_okay(self, value):
+        """Property setter for subordinate_okay"""
+        warnings.warn("subordinate_okay is deprecated. Please use "
                       "read_preference instead.", DeprecationWarning,
                       stacklevel=2)
-        self.__slave_okay = validate_boolean('slave_okay', value)
+        self.__subordinate_okay = validate_boolean('subordinate_okay', value)
 
-    slave_okay = property(__get_slave_okay, __set_slave_okay)
+    subordinate_okay = property(__get_subordinate_okay, __set_subordinate_okay)
 
     def __get_read_pref(self):
         """The read preference mode for this instance.

--- a/venv/lib/python3.7/site-packages/pymongo/connection.py
+++ b/venv/lib/python3.7/site-packages/pymongo/connection.py
@@ -17,8 +17,8 @@
 .. warning::
    **DEPRECATED:** Please use :mod:`~pymongo.mongo_client` instead.
 
-.. seealso:: Module :mod:`~pymongo.master_slave_connection` for
-   connecting to master-slave clusters, and
+.. seealso:: Module :mod:`~pymongo.main_subordinate_connection` for
+   connecting to main-subordinate clusters, and
    :doc:`/examples/high_availability` for an example of how to connect
    to a replica set, or specify a list of mongos instances for automatic
    failover.
@@ -150,7 +150,7 @@ class Connection(MongoClient):
             - either directly or via a mongos:**
           | (ignored by standalone mongod instances)
 
-          - `slave_okay` or `slaveOk` (deprecated): Use `read_preference`
+          - `subordinate_okay` or `subordinateOk` (deprecated): Use `read_preference`
             instead.
           - `replicaSet`: (string) The name of the replica-set to connect to.
             The driver will verify that the replica-set it connects to matches
@@ -160,7 +160,7 @@ class Connection(MongoClient):
           - `read_preference`: The read preference for this client. If
             connecting to a secondary then a read preference mode *other* than
             PRIMARY is required - otherwise all queries will throw a
-            :class:`~pymongo.errors.AutoReconnect` "not master" error.
+            :class:`~pymongo.errors.AutoReconnect` "not main" error.
             See :class:`~pymongo.read_preferences.ReadPreference` for all
             available read preference options. Defaults to ``PRIMARY``.
           - `tag_sets`: Ignored unless connecting to a replica-set via mongos.
@@ -206,9 +206,9 @@ class Connection(MongoClient):
         .. versionchanged:: 2.1
            Support `w` = integer or string.
            Added `ssl` option.
-           DEPRECATED slave_okay/slaveOk.
+           DEPRECATED subordinate_okay/subordinateOk.
         .. versionchanged:: 2.0
-           `slave_okay` is a pure keyword argument. Added support for safe,
+           `subordinate_okay` is a pure keyword argument. Added support for safe,
            and getlasterror options as keyword arguments.
         .. versionchanged:: 1.11
            Added `max_pool_size`. Completely removed previously deprecated

--- a/venv/lib/python3.7/site-packages/pymongo/cursor.py
+++ b/venv/lib/python3.7/site-packages/pymongo/cursor.py
@@ -27,7 +27,7 @@ from pymongo.errors import (AutoReconnect,
 
 _QUERY_OPTIONS = {
     "tailable_cursor": 2,
-    "slave_okay": 4,
+    "subordinate_okay": 4,
     "oplog_replay": 8,
     "no_timeout": 16,
     "await_data": 32,
@@ -75,11 +75,11 @@ class Cursor(object):
 
     def __init__(self, collection, spec=None, fields=None, skip=0, limit=0,
                  timeout=True, snapshot=False, tailable=False, sort=None,
-                 max_scan=None, as_class=None, slave_okay=False,
+                 max_scan=None, as_class=None, subordinate_okay=False,
                  await_data=False, partial=False, manipulate=True,
                  read_preference=ReadPreference.PRIMARY,
                  tag_sets=[{}], secondary_acceptable_latency_ms=None,
-                 exhaust=False, compile_re=True, _must_use_master=False,
+                 exhaust=False, compile_re=True, _must_use_main=False,
                  _uuid_subtype=None, **kwargs):
         """Create a new cursor.
 
@@ -105,8 +105,8 @@ class Cursor(object):
             raise TypeError("snapshot must be an instance of bool")
         if not isinstance(tailable, bool):
             raise TypeError("tailable must be an instance of bool")
-        if not isinstance(slave_okay, bool):
-            raise TypeError("slave_okay must be an instance of bool")
+        if not isinstance(subordinate_okay, bool):
+            raise TypeError("subordinate_okay must be an instance of bool")
         if not isinstance(await_data, bool):
             raise TypeError("await_data must be an instance of bool")
         if not isinstance(partial, bool):
@@ -157,14 +157,14 @@ class Cursor(object):
         self.__hint = None
         self.__comment = None
         self.__as_class = as_class
-        self.__slave_okay = slave_okay
+        self.__subordinate_okay = subordinate_okay
         self.__manipulate = manipulate
         self.__read_preference = read_preference
         self.__tag_sets = tag_sets
         self.__secondary_acceptable_latency_ms = secondary_acceptable_latency_ms
         self.__tz_aware = collection.database.connection.tz_aware
         self.__compile_re = compile_re
-        self.__must_use_master = _must_use_master
+        self.__must_use_main = _must_use_main
         self.__uuid_subtype = _uuid_subtype or collection.uuid_subtype
 
         self.__data = deque()
@@ -249,10 +249,10 @@ class Cursor(object):
         values_to_clone = ("spec", "fields", "skip", "limit", "max_time_ms",
                            "comment", "max", "min",
                            "snapshot", "ordering", "explain", "hint",
-                           "batch_size", "max_scan", "as_class", "slave_okay",
+                           "batch_size", "max_scan", "as_class", "subordinate_okay",
                            "manipulate", "read_preference", "tag_sets",
                            "secondary_acceptable_latency_ms",
-                           "must_use_master", "uuid_subtype", "compile_re",
+                           "must_use_main", "uuid_subtype", "compile_re",
                            "query_flags", "kwargs")
         data = dict((k, v) for k, v in self.__dict__.items()
                     if k.startswith('_Cursor__') and k[9:] in values_to_clone)
@@ -324,7 +324,7 @@ class Cursor(object):
 
             # For maximum backwards compatibility, don't set $readPreference
             # for SECONDARY_PREFERRED unless tags are in use. Just rely on
-            # the slaveOkay bit (set automatically if read preference is not
+            # the subordinateOkay bit (set automatically if read preference is not
             # PRIMARY), which has the same behavior.
             if (self.__read_preference != ReadPreference.SECONDARY_PREFERRED or
                 has_tags):
@@ -382,10 +382,10 @@ class Cursor(object):
         """Get the query options string to use for this query.
         """
         options = self.__query_flags
-        if (self.__slave_okay
+        if (self.__subordinate_okay
             or self.__read_preference != ReadPreference.PRIMARY
         ):
-            options |= _QUERY_OPTIONS["slave_okay"]
+            options |= _QUERY_OPTIONS["subordinate_okay"]
         return options
 
     def __check_okay_to_chain(self):
@@ -404,8 +404,8 @@ class Cursor(object):
             raise TypeError("mask must be an int")
         self.__check_okay_to_chain()
 
-        if mask & _QUERY_OPTIONS["slave_okay"]:
-            self.__slave_okay = True
+        if mask & _QUERY_OPTIONS["subordinate_okay"]:
+            self.__subordinate_okay = True
         if mask & _QUERY_OPTIONS["exhaust"]:
             if self.__limit:
                 raise InvalidOperation("Can't use limit and exhaust together.")
@@ -427,8 +427,8 @@ class Cursor(object):
             raise TypeError("mask must be an int")
         self.__check_okay_to_chain()
 
-        if mask & _QUERY_OPTIONS["slave_okay"]:
-            self.__slave_okay = False
+        if mask & _QUERY_OPTIONS["subordinate_okay"]:
+            self.__subordinate_okay = False
         if mask & _QUERY_OPTIONS["exhaust"]:
             self.__exhaust = False
 
@@ -707,12 +707,12 @@ class Cursor(object):
           collection.find({'field': 'value'}).hint('field_1').count()
 
         With :class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`
-        or :class:`~pymongo.master_slave_connection.MasterSlaveConnection`,
+        or :class:`~pymongo.main_subordinate_connection.MainSubordinateConnection`,
         if `read_preference` is not
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY` or
         :attr:`pymongo.read_preferences.ReadPreference.PRIMARY_PREFERRED`, or
-        (deprecated) `slave_okay` is `True`, the count command will be sent to
-        a secondary or slave.
+        (deprecated) `subordinate_okay` is `True`, the count command will be sent to
+        a secondary or subordinate.
 
         :Parameters:
           - `with_limit_and_skip` (optional): take any :meth:`limit` or
@@ -743,9 +743,9 @@ class Cursor(object):
         command['tag_sets'] = self.__tag_sets
         command['secondary_acceptable_latency_ms'] = (
             self.__secondary_acceptable_latency_ms)
-        command['slave_okay'] = self.__slave_okay
-        use_master = not self.__slave_okay and not self.__read_preference
-        command['_use_master'] = use_master
+        command['subordinate_okay'] = self.__subordinate_okay
+        use_main = not self.__subordinate_okay and not self.__read_preference
+        command['_use_main'] = use_main
         if self.__max_time_ms is not None:
             command["maxTimeMS"] = self.__max_time_ms
         if self.__comment:
@@ -778,11 +778,11 @@ class Cursor(object):
         :class:`basestring` (:class:`str` in python 3).
 
         With :class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`
-        or :class:`~pymongo.master_slave_connection.MasterSlaveConnection`,
+        or :class:`~pymongo.main_subordinate_connection.MainSubordinateConnection`,
         if `read_preference` is
         not :attr:`pymongo.read_preferences.ReadPreference.PRIMARY` or
-        (deprecated) `slave_okay` is `True` the distinct command will be sent
-        to a secondary or slave.
+        (deprecated) `subordinate_okay` is `True` the distinct command will be sent
+        to a secondary or subordinate.
 
         :Parameters:
           - `key`: name of key for which we want to get the distinct values
@@ -805,9 +805,9 @@ class Cursor(object):
         options['tag_sets'] = self.__tag_sets
         options['secondary_acceptable_latency_ms'] = (
             self.__secondary_acceptable_latency_ms)
-        options['slave_okay'] = self.__slave_okay
-        use_master = not self.__slave_okay and not self.__read_preference
-        options['_use_master'] = use_master
+        options['subordinate_okay'] = self.__subordinate_okay
+        use_main = not self.__subordinate_okay and not self.__read_preference
+        options['_use_main'] = use_main
         if self.__max_time_ms is not None:
             options['maxTimeMS'] = self.__max_time_ms
         if self.__comment:
@@ -919,7 +919,7 @@ class Cursor(object):
         client = self.__collection.database.connection
 
         if message:
-            kwargs = {"_must_use_master": self.__must_use_master}
+            kwargs = {"_must_use_main": self.__must_use_main}
             kwargs["read_preference"] = self.__read_preference
             kwargs["tag_sets"] = self.__tag_sets
             kwargs["secondary_acceptable_latency_ms"] = (
@@ -968,7 +968,7 @@ class Cursor(object):
                 return
             raise
         except AutoReconnect:
-            # Don't send kill cursors to another server after a "not master"
+            # Don't send kill cursors to another server after a "not main"
             # error. It's completely pointless.
             self.__killed = True
             # Make sure exhaust socket is returned immediately, if necessary.

--- a/venv/lib/python3.7/site-packages/pymongo/database.py
+++ b/venv/lib/python3.7/site-packages/pymongo/database.py
@@ -51,7 +51,7 @@ class Database(common.BaseObject):
         .. mongodoc:: databases
         """
         super(Database,
-              self).__init__(slave_okay=connection.slave_okay,
+              self).__init__(subordinate_okay=connection.subordinate_okay,
                              read_preference=connection.read_preference,
                              tag_sets=connection.tag_sets,
                              secondary_acceptable_latency_ms=(
@@ -284,27 +284,27 @@ class Database(common.BaseObject):
             command = SON([(command, value)])
 
         command_name = list(command.keys())[0].lower()
-        must_use_master = kwargs.pop('_use_master', False)
+        must_use_main = kwargs.pop('_use_main', False)
         if command_name not in secondary_ok_commands:
-            must_use_master = True
+            must_use_main = True
 
         # Special-case: mapreduce can go to secondaries only if inline
         if command_name == 'mapreduce':
             out = command.get('out') or kwargs.get('out')
             if not isinstance(out, dict) or not out.get('inline'):
-                must_use_master = True
+                must_use_main = True
 
         # Special-case: aggregate with $out cannot go to secondaries.
         if command_name == 'aggregate':
             for stage in kwargs.get('pipeline', []):
                 if '$out' in stage:
-                    must_use_master = True
+                    must_use_main = True
                     break
 
         extra_opts = {
             'as_class': kwargs.pop('as_class', None),
-            'slave_okay': kwargs.pop('slave_okay', self.slave_okay),
-            '_must_use_master': must_use_master,
+            'subordinate_okay': kwargs.pop('subordinate_okay', self.subordinate_okay),
+            '_must_use_main': must_use_main,
             '_uuid_subtype': uuid_subtype
         }
 
@@ -325,9 +325,9 @@ class Database(common.BaseObject):
 
         command.update(kwargs)
 
-        # Warn if must_use_master will override read_preference.
+        # Warn if must_use_main will override read_preference.
         if (extra_opts['read_preference'] != ReadPreference.PRIMARY and
-                extra_opts['_must_use_master'] and self.connection._rs_client):
+                extra_opts['_must_use_main'] and self.connection._rs_client):
             warnings.warn("%s does not support %s read preference "
                           "and will be routed to the primary instead." %
                           (command_name,
@@ -448,12 +448,12 @@ class Database(common.BaseObject):
         client = self.connection
         client._ensure_connected(True)
 
-        slave_okay = not client._rs_client and not client.is_mongos
+        subordinate_okay = not client._rs_client and not client.is_mongos
         if client.max_wire_version > 2:
             res, addr = self._command("listCollections",
                                       cursor={},
                                       read_preference=ReadPreference.PRIMARY,
-                                      slave_okay=slave_okay)
+                                      subordinate_okay=subordinate_okay)
             # MongoDB 2.8rc2
             if "collections" in res:
                 results = res["collections"]
@@ -464,8 +464,8 @@ class Database(common.BaseObject):
         else:
             names = [result["name"] for result
                      in self["system.namespaces"].find(
-                         slave_okay=slave_okay,
-                         _must_use_master=True)]
+                         subordinate_okay=subordinate_okay,
+                         _must_use_main=True)]
             names = [n[len(self.__name) + 1:] for n in names
                      if n.startswith(self.__name + ".") and "$" not in n]
 
@@ -659,7 +659,7 @@ class Database(common.BaseObject):
         error_msg = error.get("err", "")
         if error_msg is None:
             return None
-        if error_msg.startswith("not master"):
+        if error_msg.startswith("not main"):
             self.__connection.disconnect()
         return error
 

--- a/venv/lib/python3.7/site-packages/pymongo/helpers.py
+++ b/venv/lib/python3.7/site-packages/pymongo/helpers.py
@@ -101,7 +101,7 @@ def _unpack_response(response, cursor_id=None, as_class=dict,
                              cursor_id)
     elif response_flag & 2:
         error_object = bson.BSON(response[20:]).decode()
-        if error_object["$err"].startswith("not master"):
+        if error_object["$err"].startswith("not main"):
             raise AutoReconnect(error_object["$err"])
         elif error_object.get("code") == 50:
             raise ExecutionTimeout(error_object.get("$err"),
@@ -155,8 +155,8 @@ def _check_command_response(response, reset, msg=None, allowable_errors=None):
         errmsg = details["errmsg"]
         if allowable_errors is None or errmsg not in allowable_errors:
 
-            # Server is "not master" or "recovering"
-            if (errmsg.startswith("not master")
+            # Server is "not main" or "recovering"
+            if (errmsg.startswith("not main")
                 or errmsg.startswith("node is recovering")):
                 if reset is not None:
                     reset()

--- a/venv/lib/python3.7/site-packages/pymongo/master_slave_connection.py
+++ b/venv/lib/python3.7/site-packages/pymongo/master_slave_connection.py
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""**DEPRECATED**: Master-Slave connection to Mongo.
+"""**DEPRECATED**: Main-Subordinate connection to Mongo.
 
-Performs all writes to Master instance and distributes reads among all
-slaves. Reads are tried on each slave in turn until the read succeeds
-or all slaves failed.
+Performs all writes to Main instance and distributes reads among all
+subordinates. Reads are tried on each subordinate in turn until the read succeeds
+or all subordinates failed.
 
-MasterSlaveConnection is deprecated and will be removed in PyMongo 3.0.
-Deploy your MongoDB servers as a replica set instead of a master-slave set,
+MainSubordinateConnection is deprecated and will be removed in PyMongo 3.0.
+Deploy your MongoDB servers as a replica set instead of a main-subordinate set,
 and use a :class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`.
-If you cannot replace your master-slave set with a replica set, connect
-directly to the master and each slave with instances of
+If you cannot replace your main-subordinate set with a replica set, connect
+directly to the main and each subordinate with instances of
 :class:`~pymongo.mongo_client.MongoClient`.
 
 .. seealso:: `replica set documentation <http://dochub.mongodb.org/core/rs>`_.
@@ -41,72 +41,72 @@ from pymongo.database import Database
 from pymongo.errors import AutoReconnect
 
 
-class MasterSlaveConnection(BaseObject):
+class MainSubordinateConnection(BaseObject):
 
     _rs_client = True
 
-    def __init__(self, master, slaves=[], document_class=dict, tz_aware=False):
-        """Create a new Master-Slave connection.
+    def __init__(self, main, subordinates=[], document_class=dict, tz_aware=False):
+        """Create a new Main-Subordinate connection.
 
         The resultant connection should be interacted with using the same
         mechanisms as a regular `MongoClient`. The `MongoClient` instances used
-        to create this `MasterSlaveConnection` can themselves make use of
-        connection pooling, etc. `MongoClient` instances used as slaves should
+        to create this `MainSubordinateConnection` can themselves make use of
+        connection pooling, etc. `MongoClient` instances used as subordinates should
         be created with the read_preference option set to
         :attr:`~pymongo.read_preferences.ReadPreference.SECONDARY`. Write
-        concerns are inherited from `master` and can be changed in this
+        concerns are inherited from `main` and can be changed in this
         instance.
 
-        Raises TypeError if `master` is not an instance of `MongoClient` or
-        slaves is not a list of at least one `MongoClient` instances.
+        Raises TypeError if `main` is not an instance of `MongoClient` or
+        subordinates is not a list of at least one `MongoClient` instances.
 
         :Parameters:
-          - `master`: `MongoClient` instance for the writable Master
-          - `slaves`: list of `MongoClient` instances for the
-            read-only slaves
+          - `main`: `MongoClient` instance for the writable Main
+          - `subordinates`: list of `MongoClient` instances for the
+            read-only subordinates
           - `document_class` (optional): default class to use for
             documents returned from queries on this connection
           - `tz_aware` (optional): if ``True``,
             :class:`~datetime.datetime` instances returned as values
-            in a document by this :class:`MasterSlaveConnection` will be timezone
+            in a document by this :class:`MainSubordinateConnection` will be timezone
             aware (otherwise they will be naive)
         """
-        if not isinstance(master, MongoClient):
-            raise TypeError("master must be a MongoClient instance")
-        if not isinstance(slaves, list) or len(slaves) == 0:
-            raise TypeError("slaves must be a list of length >= 1")
+        if not isinstance(main, MongoClient):
+            raise TypeError("main must be a MongoClient instance")
+        if not isinstance(subordinates, list) or len(subordinates) == 0:
+            raise TypeError("subordinates must be a list of length >= 1")
 
-        for slave in slaves:
-            if not isinstance(slave, MongoClient):
-                raise TypeError("slave %r is not an instance of MongoClient" %
-                                slave)
+        for subordinate in subordinates:
+            if not isinstance(subordinate, MongoClient):
+                raise TypeError("subordinate %r is not an instance of MongoClient" %
+                                subordinate)
 
-        warnings.warn("MasterSlaveConnection is deprecated, and will be"
+        warnings.warn("MainSubordinateConnection is deprecated, and will be"
                       " removed in PyMongo 3.0.",
                       DeprecationWarning, stacklevel=2)
 
-        super(MasterSlaveConnection,
+        super(MainSubordinateConnection,
               self).__init__(read_preference=ReadPreference.SECONDARY,
-                             safe=master.safe,
-                             **master.write_concern)
+                             safe=main.safe,
+                             **main.write_concern)
 
-        self.__master = master
-        self.__slaves = slaves
+        self.__main = main
+        self.__subordinates = subordinates
         self.__document_class = document_class
         self.__tz_aware = tz_aware
-        self.__request_counter = thread_util.Counter(master.use_greenlets)
+        self.__request_counter = thread_util.Counter(main.use_greenlets)
 
     @property
-    def master(self):
-        return self.__master
+    def main(self):
+        return self.__main
 
     @property
-    def slaves(self):
-        return self.__slaves
+    def subordinates(self):
+        return self.__subordinates
 
     @property
     def is_mongos(self):
-        """If this MasterSlaveConnection is connected to mongos (always False)
+        """If this MainSubordinateConnection is connected to mongos (always False)
 
         .. versionadded:: 2.3
         """
@@ -119,7 +119,7 @@ class MasterSlaveConnection(BaseObject):
 
         .. versionadded:: 2.4.2
         """
-        return self.master.use_greenlets
+        return self.main.use_greenlets
 
     def get_document_class(self):
         return self.__document_class
@@ -137,21 +137,21 @@ class MasterSlaveConnection(BaseObject):
 
     @property
     def max_bson_size(self):
-        """Return the maximum size BSON object the connected master
+        """Return the maximum size BSON object the connected main
         accepts in bytes. Defaults to 4MB in server < 1.7.4.
 
         .. versionadded:: 2.6
         """
-        return self.master.max_bson_size
+        return self.main.max_bson_size
 
     @property
     def max_message_size(self):
-        """Return the maximum message size the connected master
+        """Return the maximum message size the connected main
         accepts in bytes.
 
         .. versionadded:: 2.6
         """
-        return self.master.max_message_size
+        return self.main.max_message_size
 
     @property
     def min_wire_version(self):
@@ -161,7 +161,7 @@ class MasterSlaveConnection(BaseObject):
 
         .. versionadded:: 2.7
         """
-        return self.master.min_wire_version
+        return self.main.min_wire_version
 
     @property
     def max_wire_version(self):
@@ -171,7 +171,7 @@ class MasterSlaveConnection(BaseObject):
 
         .. versionadded:: 2.7
         """
-        return self.master.max_wire_version
+        return self.main.max_wire_version
 
     @property
     def max_write_batch_size(self):
@@ -182,20 +182,20 @@ class MasterSlaveConnection(BaseObject):
 
         .. versionadded:: 2.7
         """
-        return self.master.max_write_batch_size
+        return self.main.max_write_batch_size
 
     def disconnect(self):
         """Disconnect from MongoDB.
 
-        Disconnecting will call disconnect on all master and slave
+        Disconnecting will call disconnect on all main and subordinate
         connections.
 
         .. seealso:: Module :mod:`~pymongo.mongo_client`
         .. versionadded:: 1.10.1
         """
-        self.__master.disconnect()
-        for slave in self.__slaves:
-            slave.disconnect()
+        self.__main.disconnect()
+        for subordinate in self.__subordinates:
+            subordinate.disconnect()
 
     def close(self):
         """Alias for :meth:`disconnect`
@@ -209,23 +209,23 @@ class MasterSlaveConnection(BaseObject):
         """Set the cursor manager for this connection.
 
         Helper to set cursor manager for each individual `MongoClient` instance
-        that make up this `MasterSlaveConnection`.
+        that make up this `MainSubordinateConnection`.
         """
-        self.__master.set_cursor_manager(manager_class)
-        for slave in self.__slaves:
-            slave.set_cursor_manager(manager_class)
+        self.__main.set_cursor_manager(manager_class)
+        for subordinate in self.__subordinates:
+            subordinate.set_cursor_manager(manager_class)
 
     def _ensure_connected(self, sync):
-        """Ensure the master is connected to a mongod/s.
+        """Ensure the main is connected to a mongod/s.
         """
-        self.__master._ensure_connected(sync)
+        self.__main._ensure_connected(sync)
 
     def _send_message(self, message,
                       with_last_error=False,
                       command=False):
         """Say something to Mongo.
 
-        Sends a message on the Master connection. This is used for inserts,
+        Sends a message on the Main connection. This is used for inserts,
         updates, and deletes.
 
         Raises ConnectionFailure if the message cannot be sent. Returns the
@@ -236,14 +236,14 @@ class MasterSlaveConnection(BaseObject):
           - `data`: data to send
           - `safe`: perform a getLastError after sending the message
         """
-        return self.__master._send_message(message,
+        return self.__main._send_message(message,
                                            with_last_error, command)
 
     # _connection_to_use is a hack that we need to include to make sure
     # that getmore operations can be sent to the same instance on which
     # the cursor actually resides...
     def _send_message_with_response(self, message, _connection_to_use=None,
-                                    _must_use_master=False, **kwargs):
+                                    _must_use_main=False, **kwargs):
         """Receive a message from Mongo.
 
         Sends the given message and returns a (connection_id, response) pair.
@@ -254,43 +254,43 @@ class MasterSlaveConnection(BaseObject):
         """
         if _connection_to_use is not None:
             if _connection_to_use == -1:
-                member = self.__master
+                member = self.__main
                 conn = -1
             else:
-                member = self.__slaves[_connection_to_use]
+                member = self.__subordinates[_connection_to_use]
                 conn = _connection_to_use
             return (conn,
                     member._send_message_with_response(message, **kwargs)[1])
 
-        # _must_use_master is set for commands, which must be sent to the
-        # master instance. any queries in a request must be sent to the
-        # master since that is where writes go.
-        if _must_use_master or self.in_request():
-            return (-1, self.__master._send_message_with_response(message,
+        # _must_use_main is set for commands, which must be sent to the
+        # main instance. any queries in a request must be sent to the
+        # main since that is where writes go.
+        if _must_use_main or self.in_request():
+            return (-1, self.__main._send_message_with_response(message,
                                                                   **kwargs)[1])
 
-        # Iterate through the slaves randomly until we have success. Raise
+        # Iterate through the subordinates randomly until we have success. Raise
         # reconnect if they all fail.
-        for connection_id in helpers.shuffled(range(len(self.__slaves))):
+        for connection_id in helpers.shuffled(range(len(self.__subordinates))):
             try:
-                slave = self.__slaves[connection_id]
+                subordinate = self.__subordinates[connection_id]
                 return (connection_id,
-                        slave._send_message_with_response(message,
+                        subordinate._send_message_with_response(message,
                                                           **kwargs)[1])
             except AutoReconnect:
                 pass
 
-        raise AutoReconnect("failed to connect to slaves")
+        raise AutoReconnect("failed to connect to subordinates")
 
     def start_request(self):
         """Start a "request".
 
         Start a sequence of operations in which order matters. Note
         that all operations performed within a request will be sent
-        using the Master connection.
+        using the Main connection.
         """
         self.__request_counter.inc()
-        self.master.start_request()
+        self.main.start_request()
 
     def in_request(self):
         return bool(self.__request_counter.get())
@@ -301,12 +301,12 @@ class MasterSlaveConnection(BaseObject):
         See documentation for `MongoClient.end_request`.
         """
         self.__request_counter.dec()
-        self.master.end_request()
+        self.main.end_request()
 
     def __eq__(self, other):
-        if isinstance(other, MasterSlaveConnection):
-            us = (self.__master, self.slaves)
-            them = (other.__master, other.__slaves)
+        if isinstance(other, MainSubordinateConnection):
+            us = (self.__main, self.subordinates)
+            them = (other.__main, other.__subordinates)
             return us == them
         return NotImplemented
 
@@ -314,7 +314,7 @@ class MasterSlaveConnection(BaseObject):
         return not self == other
 
     def __repr__(self):
-        return "MasterSlaveConnection(%r, %r)" % (self.__master, self.__slaves)
+        return "MainSubordinateConnection(%r, %r)" % (self.__main, self.__subordinates)
 
     def __getattr__(self, name):
         """Get a database by name.
@@ -349,13 +349,13 @@ class MasterSlaveConnection(BaseObject):
             was opened
         """
         if connection_id == -1:
-            return self.__master.close_cursor(cursor_id)
-        return self.__slaves[connection_id].close_cursor(cursor_id)
+            return self.__main.close_cursor(cursor_id)
+        return self.__subordinates[connection_id].close_cursor(cursor_id)
 
     def database_names(self):
         """Get a list of all database names.
         """
-        return self.__master.database_names()
+        return self.__main.database_names()
 
     def drop_database(self, name_or_database):
         """Drop a database.
@@ -364,48 +364,48 @@ class MasterSlaveConnection(BaseObject):
           - `name_or_database`: the name of a database to drop or the object
             itself
         """
-        return self.__master.drop_database(name_or_database)
+        return self.__main.drop_database(name_or_database)
 
     def __iter__(self):
         return self
 
     def __next__(self):
-        raise TypeError("'MasterSlaveConnection' object is not iterable")
+        raise TypeError("'MainSubordinateConnection' object is not iterable")
 
     def _cached(self, database_name, collection_name, index_name):
-        return self.__master._cached(database_name,
+        return self.__main._cached(database_name,
                                      collection_name, index_name)
 
     def _cache_index(self, database_name, collection_name,
                      index_name, cache_for):
-        return self.__master._cache_index(database_name, collection_name,
+        return self.__main._cache_index(database_name, collection_name,
                                           index_name, cache_for)
 
     def _purge_index(self, database_name,
                      collection_name=None, index_name=None):
-        return self.__master._purge_index(database_name,
+        return self.__main._purge_index(database_name,
                                           collection_name,
                                           index_name)
 
     def server_info(self):
-        """Get information about the MongoDB master we're connected to.
+        """Get information about the MongoDB main we're connected to.
 
         .. versionadded:: 2.8
         """
-        return self.__master.admin.command("buildinfo")
+        return self.__main.admin.command("buildinfo")
 
     def _cache_credentials(self, source, credentials, connect=True):
-        self.__master._cache_credentials(source, credentials, connect)
-        for slave in self.__slaves:
+        self.__main._cache_credentials(source, credentials, connect)
+        for subordinate in self.__subordinates:
             # Use connect=False here so that credentials are cached
-            # on the slaves no matter what. Since auth succeeded on the
-            # master we know the credentials are correct and the slaves
-            # will authenticate as needed. This avoids issues with slave
+            # on the subordinates no matter what. Since auth succeeded on the
+            # main we know the credentials are correct and the subordinates
+            # will authenticate as needed. This avoids issues with subordinate
             # auth problems due to problems other than bad credentials
             # (e.g. network errors).
-            slave._cache_credentials(source, credentials, connect=False)
+            subordinate._cache_credentials(source, credentials, connect=False)
 
     def _purge_credentials(self, source):
-        self.__master._purge_credentials(source)
-        for slave in self.__slaves:
-            slave._purge_credentials(source)
+        self.__main._purge_credentials(source)
+        for subordinate in self.__subordinates:
+            subordinate._purge_credentials(source)

--- a/venv/lib/python3.7/site-packages/pymongo/member.py
+++ b/venv/lib/python3.7/site-packages/pymongo/member.py
@@ -32,39 +32,39 @@ class Member(object):
     :Parameters:
       - `host`: A (host, port) pair
       - `connection_pool`: A Pool instance
-      - `ismaster_response`: A dict, MongoDB's ismaster response
+      - `ismain_response`: A dict, MongoDB's ismain response
       - `ping_time`: A MovingAverage instance
     """
     # For unittesting only. Use under no circumstances!
     _host_to_ping_time = {}
 
-    def __init__(self, host, connection_pool, ismaster_response, ping_time):
+    def __init__(self, host, connection_pool, ismain_response, ping_time):
         self.host = host
         self.pool = connection_pool
-        self.ismaster_response = ismaster_response
+        self.ismain_response = ismain_response
         self.ping_time = ping_time
-        self.is_mongos = (ismaster_response.get('msg') == 'isdbgrid')
+        self.is_mongos = (ismain_response.get('msg') == 'isdbgrid')
 
-        if ismaster_response['ismaster']:
+        if ismain_response['ismain']:
             self.state = PRIMARY
-        elif ismaster_response.get('secondary'):
+        elif ismain_response.get('secondary'):
             self.state = SECONDARY
-        elif ismaster_response.get('arbiterOnly'):
+        elif ismain_response.get('arbiterOnly'):
             self.state = ARBITER
         else:
             self.state = OTHER
 
-        self.set_name = ismaster_response.get('setName')
-        self.tags = ismaster_response.get('tags', {})
-        self.max_bson_size = ismaster_response.get(
+        self.set_name = ismain_response.get('setName')
+        self.tags = ismain_response.get('tags', {})
+        self.max_bson_size = ismain_response.get(
             'maxBsonObjectSize', common.MAX_BSON_SIZE)
-        self.max_message_size = ismaster_response.get(
+        self.max_message_size = ismain_response.get(
             'maxMessageSizeBytes', 2 * self.max_bson_size)
-        self.min_wire_version = ismaster_response.get(
+        self.min_wire_version = ismain_response.get(
             'minWireVersion', common.MIN_WIRE_VERSION)
-        self.max_wire_version = ismaster_response.get(
+        self.max_wire_version = ismain_response.get(
             'maxWireVersion', common.MAX_WIRE_VERSION)
-        self.max_write_batch_size = ismaster_response.get(
+        self.max_write_batch_size = ismain_response.get(
             'maxWriteBatchSize', common.MAX_WRITE_BATCH_SIZE)
 
         # self.min/max_wire_version is the server's wire protocol.
@@ -83,11 +83,11 @@ class Member(object):
                    common.MIN_SUPPORTED_WIRE_VERSION,
                    common.MAX_SUPPORTED_WIRE_VERSION))
 
-    def clone_with(self, ismaster_response, ping_time_sample):
-        """Get a clone updated with ismaster response and a single ping time.
+    def clone_with(self, ismain_response, ping_time_sample):
+        """Get a clone updated with ismain response and a single ping time.
         """
         ping_time = self.ping_time.clone_with(ping_time_sample)
-        return Member(self.host, self.pool, ismaster_response, ping_time)
+        return Member(self.host, self.pool, ismain_response, ping_time)
 
     @property
     def is_primary(self):

--- a/venv/lib/python3.7/site-packages/pymongo/mongo_client.py
+++ b/venv/lib/python3.7/site-packages/pymongo/mongo_client.py
@@ -14,8 +14,8 @@
 
 """Tools for connecting to MongoDB.
 
-.. seealso:: Module :mod:`~pymongo.master_slave_connection` for
-   connecting to master-slave clusters, and
+.. seealso:: Module :mod:`~pymongo.main_subordinate_connection` for
+   connecting to main-subordinate clusters, and
    :doc:`/examples/high_availability` for an example of how to connect
    to a replica set, or specify a list of mongos instances for automatic
    failover.
@@ -195,7 +195,7 @@ class MongoClient(common.BaseObject):
           - `read_preference`: The read preference for this client. If
             connecting to a secondary then a read preference mode *other* than
             PRIMARY is required - otherwise all queries will throw
-            :class:`~pymongo.errors.AutoReconnect` "not master".
+            :class:`~pymongo.errors.AutoReconnect` "not main".
             See :class:`~pymongo.read_preferences.ReadPreference` for all
             available read preference options. Defaults to ``PRIMARY``.
           - `tag_sets`: Ignored unless connecting to a replica set via mongos.
@@ -365,8 +365,8 @@ class MongoClient(common.BaseObject):
         self.__auth_credentials = {}
 
         super(MongoClient, self).__init__(**options)
-        if self.slave_okay:
-            warnings.warn("slave_okay is deprecated. Please "
+        if self.subordinate_okay:
+            warnings.warn("subordinate_okay is deprecated. Please "
                           "use read_preference instead.", DeprecationWarning,
                           stacklevel=2)
 
@@ -547,7 +547,7 @@ class MongoClient(common.BaseObject):
     @property
     def is_primary(self):
         """If this instance is connected to a standalone, a replica set
-        primary, or the master of a master-slave set.
+        primary, or the main of a main-subordinate set.
 
         .. versionadded:: 2.3
         """
@@ -712,13 +712,13 @@ class MongoClient(common.BaseObject):
         :Parameters:
          - `node`: The (host, port) pair to try.
         """
-        # Call 'ismaster' directly so we can get a response time.
+        # Call 'ismain' directly so we can get a response time.
         connection_pool = self.__create_pool(node)
         sock_info = connection_pool.get_socket()
         try:
             response, res_time = self.__simple_command(sock_info,
                                                        'admin',
-                                                       {'ismaster': 1})
+                                                       {'ismain': 1})
         finally:
             connection_pool.maybe_return_socket(sock_info)
 
@@ -751,7 +751,7 @@ class MongoClient(common.BaseObject):
                 return self.__try_node(candidate)
 
             # Explain why we aren't using this connection.
-            raise AutoReconnect('%s:%d is not primary or master' % node)
+            raise AutoReconnect('%s:%d is not primary or main' % node)
 
         # Direct connection
         if member.is_arbiter and not self.__direct:
@@ -844,7 +844,7 @@ class MongoClient(common.BaseObject):
         Returns a Member and a set of nodes. Doesn't modify state.
 
         If only one host was supplied to __init__ see if we can connect
-        to it. Don't check if the host is a master/primary so we can make
+        to it. Don't check if the host is a main/primary so we can make
         a direct connection to read from a secondary or send commands to
         an arbiter.
 
@@ -1057,7 +1057,7 @@ class MongoClient(common.BaseObject):
         error_msg = result.get("err", "")
         if error_msg is None:
             return result
-        if error_msg.startswith("not master"):
+        if error_msg.startswith("not main"):
             self.disconnect()
             raise AutoReconnect(error_msg)
 
@@ -1114,7 +1114,7 @@ class MongoClient(common.BaseObject):
         member = self.__ensure_member()
         if not with_last_error and not self.is_primary:
             # The write won't succeed, bail as if we'd done a getLastError
-            raise AutoReconnect("not master")
+            raise AutoReconnect("not main")
 
         sock_info = self.__socket(member)
         try:
@@ -1185,10 +1185,10 @@ class MongoClient(common.BaseObject):
             sock_info.close()
             raise
 
-    # we just ignore _must_use_master here: it's only relevant for
-    # MasterSlaveConnection instances.
+    # we just ignore _must_use_main here: it's only relevant for
+    # MainSubordinateConnection instances.
     def _send_message_with_response(self, message,
-                                    _must_use_master=False, **kwargs):
+                                    _must_use_main=False, **kwargs):
         """Send a message to Mongo and return the response.
 
         Sends the given message and returns the response.
@@ -1373,14 +1373,14 @@ class MongoClient(common.BaseObject):
     def database_names(self):
         """Get a list of the names of all databases on the connected server.
         """
-        # SERVER-15994 changed listDatabases to require slaveOk when run
-        # against a secondary / slave. Passing slave_okay=True makes things
+        # SERVER-15994 changed listDatabases to require subordinateOk when run
+        # against a secondary / subordinate. Passing subordinate_okay=True makes things
         # consistent across server versions.
         return [db["name"] for db in
                 self.admin.command(
                     "listDatabases",
                     read_preference=ReadPreference.PRIMARY,
-                    slave_okay=not self.is_mongos)["databases"]]
+                    subordinate_okay=not self.is_mongos)["databases"]]
 
     def drop_database(self, name_or_database):
         """Drop a database.

--- a/venv/lib/python3.7/site-packages/pymongo/mongo_replica_set_client.py
+++ b/venv/lib/python3.7/site-packages/pymongo/mongo_replica_set_client.py
@@ -114,7 +114,7 @@ def _partition_node(node):
 # In __init__, MongoReplicaSetClient gets a list of potential members called
 # 'seeds' from its initial parameters, and calls refresh(). refresh() iterates
 # over the the seeds in arbitrary order looking for a member it can connect to.
-# Once it finds one, it calls 'ismaster' and sets self.__hosts to the list of
+# Once it finds one, it calls 'ismain' and sets self.__hosts to the list of
 # members in the response, and connects to the rest of the members. refresh()
 # sets the MongoReplicaSetClient's RSState. Finally, __init__ launches the
 # replica-set monitor.
@@ -137,7 +137,7 @@ class RSState(object):
 
         Stores Member instances for all members we're connected to, and a
         list of (host, port) pairs for all the hosts and arbiters listed
-        in the most recent ismaster response.
+        in the most recent ismain response.
 
         :Parameters:
           - `threadlocal`: Thread- or greenlet-local storage
@@ -212,7 +212,7 @@ class RSState(object):
 
     @property
     def arbiters(self):
-        """(host, port) pairs from the last ismaster response's arbiter list.
+        """(host, port) pairs from the last ismain response's arbiter list.
         """
         return self._arbiters
 
@@ -227,7 +227,7 @@ class RSState(object):
 
     @property
     def hosts(self):
-        """(host, port) pairs from the last ismaster response's host list."""
+        """(host, port) pairs from the last ismain response's host list."""
         return self._hosts
 
     @property
@@ -686,8 +686,8 @@ class MongoReplicaSetClient(common.BaseObject):
                                      "from PyPI.")
 
         super(MongoReplicaSetClient, self).__init__(**self.__opts)
-        if self.slave_okay:
-            warnings.warn("slave_okay is deprecated. Please "
+        if self.subordinate_okay:
+            warnings.warn("subordinate_okay is deprecated. Please "
                           "use read_preference instead.", DeprecationWarning,
                           stacklevel=2)
 
@@ -860,7 +860,7 @@ class MongoReplicaSetClient(common.BaseObject):
     def hosts(self):
         """All active and passive (priority 0) replica set
         members known to this client. This does not include
-        hidden or slaveDelay members, or arbiters.
+        hidden or subordinateDelay members, or arbiters.
 
         A sequence of (host, port) pairs.
         """
@@ -1032,8 +1032,8 @@ class MongoReplicaSetClient(common.BaseObject):
         helpers._check_command_response(response, None, msg)
         return response, end - start
 
-    def __is_master(self, host):
-        """Directly call ismaster.
+    def __is_main(self, host):
+        """Directly call ismain.
            Returns (response, connection_pool, ping_time in seconds).
         """
         connection_pool = self.pool_class(
@@ -1057,7 +1057,7 @@ class MongoReplicaSetClient(common.BaseObject):
         sock_info = connection_pool.get_socket()
         try:
             response, ping_time = self.__simple_command(
-                sock_info, 'admin', {'ismaster': 1}
+                sock_info, 'admin', {'ismain': 1}
             )
 
             connection_pool.maybe_return_socket(sock_info)
@@ -1144,11 +1144,11 @@ class MongoReplicaSetClient(common.BaseObject):
                 if member:
                     sock_info = self.__socket(member, force=True)
                     response, ping_time = self.__simple_command(
-                        sock_info, 'admin', {'ismaster': 1})
+                        sock_info, 'admin', {'ismain': 1})
                     member.maybe_return_socket(sock_info)
                     new_member = member.clone_with(response, ping_time)
                 else:
-                    response, pool, ping_time = self.__is_master(node)
+                    response, pool, ping_time = self.__is_main(node)
                     new_member = Member(
                         node, pool, response, MovingAverage([ping_time]))
 
@@ -1178,7 +1178,7 @@ class MongoReplicaSetClient(common.BaseObject):
                 # but don't add seed list members.
                 if node in hosts:
                     members[node] = new_member
-                    if response['ismaster']:
+                    if response['ismain']:
                         writer = node
 
             except (ConnectionFailure, socket.error, OperationFailure) as why:
@@ -1207,7 +1207,7 @@ class MongoReplicaSetClient(common.BaseObject):
                 if member:
                     sock_info = self.__socket(member, force=True)
                     res, ping_time = self.__simple_command(
-                        sock_info, 'admin', {'ismaster': 1})
+                        sock_info, 'admin', {'ismain': 1})
 
                     if res.get('setName') != self.__name:
                         # Not a member of this set.
@@ -1216,7 +1216,7 @@ class MongoReplicaSetClient(common.BaseObject):
                     member.maybe_return_socket(sock_info)
                     new_member = member.clone_with(res, ping_time)
                 else:
-                    res, connection_pool, ping_time = self.__is_master(host)
+                    res, connection_pool, ping_time = self.__is_main(host)
                     if res.get('setName') != self.__name:
                         # Not a member of this set.
                         continue
@@ -1233,7 +1233,7 @@ class MongoReplicaSetClient(common.BaseObject):
                     member.discard_socket(sock_info)
                 continue
 
-            if res['ismaster']:
+            if res['ismain']:
                 writer = host
 
         if not members:
@@ -1255,9 +1255,9 @@ class MongoReplicaSetClient(common.BaseObject):
         # Get list of hosts in the RS config, including unreachable ones.
         # Prefer the primary's list, otherwise any member's list.
         if writer:
-            response = members[writer].ismaster_response
+            response = members[writer].ismain_response
         elif members:
-            response = list(members.values())[0].ismaster_response
+            response = list(members.values())[0].ismain_response
         else:
             response = {}
 
@@ -1424,7 +1424,7 @@ class MongoReplicaSetClient(common.BaseObject):
         error_msg = result.get("err", "")
         if error_msg is None:
             return result
-        if error_msg.startswith("not master"):
+        if error_msg.startswith("not main"):
             self.disconnect()
             raise AutoReconnect(error_msg)
 
@@ -1590,7 +1590,7 @@ class MongoReplicaSetClient(common.BaseObject):
             raise AutoReconnect("%s:%d: %s" % (host, port, why))
 
     def _send_message_with_response(self, msg, _connection_to_use=None,
-                                    _must_use_master=False, **kwargs):
+                                    _must_use_main=False, **kwargs):
         """Send a message to Mongo and return the response.
 
         Sends the given message and returns (host used, response).
@@ -1599,14 +1599,14 @@ class MongoReplicaSetClient(common.BaseObject):
           - `msg`: (request_id, data) pair making up the message to send
           - `_connection_to_use`: Optional (host, port) of member for message,
             used by Cursor for getMore and killCursors messages.
-          - `_must_use_master`: If True, send to primary.
+          - `_must_use_main`: If True, send to primary.
         """
         self._ensure_connected()
 
         rs_state = self.__get_rs_state()
         tag_sets = kwargs.get('tag_sets', [{}])
         mode = kwargs.get('read_preference', ReadPreference.PRIMARY)
-        if _must_use_master:
+        if _must_use_main:
             mode = ReadPreference.PRIMARY
             tag_sets = [{}]
 
@@ -1662,7 +1662,7 @@ class MongoReplicaSetClient(common.BaseObject):
                     pinned_member.host,
                     self.__try_read(pinned_member, msg, **kwargs))
             except AutoReconnect as why:
-                if _must_use_master or mode == ReadPreference.PRIMARY:
+                if _must_use_main or mode == ReadPreference.PRIMARY:
                     self.disconnect()
                     raise
                 else:

--- a/venv/lib/python3.7/site-packages/pymongo/replica_set_connection.py
+++ b/venv/lib/python3.7/site-packages/pymongo/replica_set_connection.py
@@ -161,7 +161,7 @@ class ReplicaSetConnection(MongoReplicaSetClient):
 
           | **Read preference options:**
 
-          - `slave_okay` or `slaveOk` (deprecated): Use `read_preference`
+          - `subordinate_okay` or `subordinateOk` (deprecated): Use `read_preference`
             instead.
           - `read_preference`: The read preference for this connection.
             See :class:`~pymongo.read_preferences.ReadPreference` for available


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.